### PR TITLE
Laravel 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Simple Dropin package to add attachments to your models.
 
 ## Install
 
-```bash
-composer require dcodegroup/laravel-attachments
-```
+| Version / Branch | Laravel Support | Install Command                                        |
+|------------------|-----------------|--------------------------------------------------------|
+| 0.x              | <= v10          | `composer require dcodegroup/laravel-attachments:^0.*` |
+| 1.x              | >= v11          | `composer require dcodegroup/laravel-attachments:^1.*` |
 
 Then run
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Simple Dropin package to add attachments to your models.
 [![Total Downloads](https://img.shields.io/packagist/dt/dcodegroup/laravel-attachments.svg?style=flat-square)](https://packagist.org/packages/dcodegroup/laravel-attachments)
 
 ## Install
-
 | Version / Branch | Laravel Support | Install Command                                        |
 |------------------|-----------------|--------------------------------------------------------|
 | 0.x              | <= v10          | `composer require dcodegroup/laravel-attachments:^0.*` |

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Simple Dropin package to add attachments to your models.
 ## Install
 | Version / Branch | Laravel Support | Install Command                                        |
 |------------------|-----------------|--------------------------------------------------------|
-| 0.x              | <= v10          | `composer require dcodegroup/laravel-attachments:^0.*` |
-| 1.x              | >= v11          | `composer require dcodegroup/laravel-attachments:^1.*` |
+| 0.x              | <= v10          | `composer require dcodegroup/laravel-attachments:^0.0` |
+| 1.x              | >= v11          | `composer require dcodegroup/laravel-attachments:^1.0` |
 
 Then run
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": "^8.2 || ^8.3",
         "ext-imagick": "*",
-        "dcodegroup/laravel-cloudfront-url-signer": "dev-master",
+        "dcodegroup/laravel-cloudfront-url-signer": "^3.6",
         "laravel/framework": "^11.0",
         "mvanduijker/laravel-model-exists-rule": "^3.0",
         "spatie/laravel-medialibrary": "^11.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": "^8.2 || ^8.3",
         "ext-imagick": "*",
-        "dcodegroup/laravel-cloudfront-url-signer": "^3.0",
+        "dcodegroup/laravel-cloudfront-url-signer": "dev-master",
         "laravel/framework": "^11.0",
         "mvanduijker/laravel-model-exists-rule": "^3.0",
         "spatie/laravel-medialibrary": "^11.0",

--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,22 @@
             "homepage": "https://www.lionslair.net.au"
         },
         {
+            "name": "Aaron Heath",
+            "email": "aaron@aaronheath.com",
+            "role": "Developer",
+            "homepage": "https://aaronheath.com"
+        },
+        {
             "name": "Dcode Group",
             "email": "forge@dcodegroup.com",
             "homepage": "https://dcodegroup.com"
         }
     ],
     "require": {
-        "php": "^8.2||^8.3",
+        "php": "^8.2 || ^8.3",
         "ext-imagick": "*",
-        "dreamonkey/laravel-cloudfront-url-signer": "^3.4",
-        "laravel/framework": "^9.0 || ^10.0 || ^11.0",
+        "dcodegroup/laravel-cloudfront-url-signer": "^3.0",
+        "laravel/framework": "^11.0",
         "mvanduijker/laravel-model-exists-rule": "^3.0",
         "spatie/laravel-medialibrary": "^11.0",
         "spatie/pdf-to-image": "^2.2"
@@ -37,7 +43,7 @@
         "ergebnis/composer-normalize": "^2.42",
         "larastan/larastan": "^2.9",
         "laravel/pint": "^1.13",
-        "orchestra/testbench": "^8.21",
+        "orchestra/testbench": "^9.0",
         "phpstan/phpstan-deprecation-rules": "^1.1",
         "phpstan/phpstan-phpunit": "^1.3"
     },


### PR DESCRIPTION
Existing v0.x releases to be retained in a renamed `master` branch to `0.x`. All `0.x.x` tags to come from this branch.

New project primary branch `1.x` will this branch merged into it providing the basis for the future and Laravel v11+ support. All `1.x.x` tags to come from this branch.

For more information see starter project Laravel 11 PR for details: https://github.com/DCODE-GROUP/project-starter/pull/50